### PR TITLE
Limit skribisto version and more

### DIFF
--- a/eu.skribisto.skribisto.yml
+++ b/eu.skribisto.skribisto.yml
@@ -27,3 +27,4 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)
+          versions: {<: '2.0'}

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "disable-external-data-checker": false
-}


### PR DESCRIPTION
### Limit skribisto version

Limit Scribisto version to disable FEDC-related noise.

> The checkers can support version constraining, making it possible to e.g.
> limit version checking to a certain major version.

Source: https://github.com/flathub-infra/flatpak-external-data-checker?tab=readme-ov-file#version-constraining

### Remove flathub.json

Since the default behavior of disable-external-data-checker is false, this option and the flathub.json file are redundant.